### PR TITLE
Polyglot Fixes

### DIFF
--- a/classes/EnhancedJournalEntry.js
+++ b/classes/EnhancedJournalEntry.js
@@ -2,7 +2,7 @@ import { DCConfig } from "../apps/dc-config.js";
 import { SlideConfig } from "../apps/slideconfig.js";
 import { TrapConfig } from "../apps/trap-config.js";
 import { Objectives } from "../apps/objectives.js";
-import { setting, i18n, log, makeid, MonksEnhancedJournal } from "../monks-enhanced-journal.js";
+import { setting, i18n, log, makeid, MonksEnhancedJournal, polyglotLanguageProvider } from "../monks-enhanced-journal.js";
 
 export class SubSheet {
     constructor(object) {
@@ -65,9 +65,6 @@ export class SubSheet {
         this.activateListeners($(this.element));
 
         if (game.modules.get("polyglot")?.active) {
-            this.known_languages = new Set();
-            [this.known_languages] = MonksEnhancedJournal.polyglot?.getUserLanguages([game.user.character]);
-
             this.renderPolyglot();
         }
 
@@ -212,11 +209,12 @@ export class SubSheet {
             const lang = this.dataset.language;
             if (!lang) return;
 
-            let scramble = MonksEnhancedJournal.polyglot.scrambleString(this.textContent, game.settings.get('polyglot', 'useUniqueSalt') ? that.object.id : lang, lang);
-            let scrambleSpan = $('<span>').addClass('polyglot-scramble').css({ 'font': MonksEnhancedJournal.polyglot._getFontStyle(lang) }).html(scramble);
+            let scramble = polyglot.polyglot.scrambleString(this.textContent, game.settings.get('polyglot', 'useUniqueSalt') ? that.object.id : lang, lang);
+            let scrambleSpan = $('<span>').addClass('polyglot-scramble').css({ 'font': polyglot.polyglot._getFontStyle(lang) }).html(scramble);
+						
             $('<div>')
                 .addClass('polyglot-container')
-                .attr('data-language', (game.user.isGM || that.object.permission == CONST.ENTITY_PERMISSIONS.OWNER || that.known_languages.has(lang) ? MonksEnhancedJournal.polyglot.constructor.languages[lang] : 'Unknown'))
+                .attr('data-language', (game.user.isGM || that.object.permission == CONST.ENTITY_PERMISSIONS.OWNER || polyglot.polyglot.known_languages.has(lang) ? polyglotLanguageProvider.languages[lang] : 'Unknown'))
                 .insertBefore($(this).addClass('converted').attr('title', ''))
                 .append(this)
                 .append(scrambleSpan)
@@ -224,7 +222,7 @@ export class SubSheet {
                     function () {
                         //hover in
                         const lang = this.dataset.language;
-                        if (game.user.isGM || that.object.permission == CONST.ENTITY_PERMISSIONS.OWNER || that.known_languages.has(lang)) {
+                        if (game.user.isGM || that.object.permission == CONST.ENTITY_PERMISSIONS.OWNER || polyglot.polyglot.known_languages.has(lang)) {
                             $(this).addClass('translate');
                         }
                     },

--- a/classes/EnhancedJournalEntry.js
+++ b/classes/EnhancedJournalEntry.js
@@ -2,7 +2,7 @@ import { DCConfig } from "../apps/dc-config.js";
 import { SlideConfig } from "../apps/slideconfig.js";
 import { TrapConfig } from "../apps/trap-config.js";
 import { Objectives } from "../apps/objectives.js";
-import { setting, i18n, log, makeid, MonksEnhancedJournal, polyglotLanguageProvider } from "../monks-enhanced-journal.js";
+import { setting, i18n, log, makeid, MonksEnhancedJournal } from "../monks-enhanced-journal.js";
 
 export class SubSheet {
     constructor(object) {
@@ -214,7 +214,7 @@ export class SubSheet {
 						
             $('<div>')
                 .addClass('polyglot-container')
-                .attr('data-language', (game.user.isGM || that.object.permission == CONST.ENTITY_PERMISSIONS.OWNER || polyglot.polyglot.known_languages.has(lang) ? polyglotLanguageProvider.languages[lang] : 'Unknown'))
+                .attr('data-language', (game.user.isGM || that.object.permission == CONST.ENTITY_PERMISSIONS.OWNER || polyglot.polyglot.known_languages.has(lang) ? polyglot.polyglot.LanguageProvider.languages[lang] : 'Unknown'))
                 .insertBefore($(this).addClass('converted').attr('title', ''))
                 .append(this)
                 .append(scrambleSpan)

--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -33,8 +33,6 @@ export let oldSheetClass = () => {
     return MonksEnhancedJournal._oldSheetClass;
 };
 
-export let polyglotLanguageProvider = undefined;
-
 export class MonksEnhancedJournal {
     static _oldSheetClass;
     static journal;
@@ -311,11 +309,6 @@ export class MonksEnhancedJournal {
         //Hooks.on("closeJournalSheet", (app, html, data) => {
         //    this._onJournalRemoved(app);
         //});
-
-        if (game.modules.get("polyglot")?.active) {
-            const importedJS = await import("/modules/polyglot/module/api.js");
-            polyglotLanguageProvider = importedJS.currentLanguageProvider;
-        }
 
         tinyMCE.PluginManager.add('background', backgroundinit);
     }

--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -33,6 +33,8 @@ export let oldSheetClass = () => {
     return MonksEnhancedJournal._oldSheetClass;
 };
 
+export let polyglotLanguageProvider = undefined;
+
 export class MonksEnhancedJournal {
     static _oldSheetClass;
     static journal;
@@ -311,10 +313,8 @@ export class MonksEnhancedJournal {
         //});
 
         if (game.modules.get("polyglot")?.active) {
-            //import {Polyglot} from "./module/logic.js";
-            const importedJS = await import("/modules/polyglot/module/logic.js");
-            this.polyglot = new importedJS.Polyglot();
-            this.polyglot.loadLanguages();
+            const importedJS = await import("/modules/polyglot/module/api.js");
+            polyglotLanguageProvider = importedJS.currentLanguageProvider;
         }
 
         tinyMCE.PluginManager.add('background', backgroundinit);


### PR DESCRIPTION
Hey, I've updated Polyglot with an API and it seems to have broken Enhanced Journal.
The good news is that the Polyglot object is now global (polyglot.polyglot), so no need to make a `this.polyglot` to call its methods. ~~It still needs to target the LanguageProvider, as in EnhancedJournalEntry.js line 217, though, but I'll get this fixed on the next Polyglot update.~~
https://github.com/League-of-Foundry-Developers/fvtt-module-polyglot/issues/160