### PR TITLE
Polyglot fix

### DIFF
--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -921,7 +921,10 @@ export class MonksEnhancedJournal {
 
         if (game.modules.get("polyglot")?.active) {
             let root = $('<div>').attr('id', 'enhanced-journal-fonts').appendTo('body');
-            for (let [k, v] of Object.entries(polyglot.polyglot.LanguageProvider.alphabets)) {
+			let alphabets = isNewerVersion(game.modules.get("polyglot").data.version, "1.7.30")
+				? game.polyglot.LanguageProvider.alphabets
+				: polyglot.polyglot.LanguageProvider.alphabets;
+			for (let [k, v] of Object.entries(alphabets)) {
                 $('<span>').attr('lang', k).css({ font: v }).appendTo(root);
             }
         }


### PR DESCRIPTION
Next Polyglot version will introduce breaking changes to the way it gets its alphabet. It's just a change from `polyglot.polyglot` to `game.polyglot`, so this should make it work for both versions.