### PR TITLE
Fixed an issue when creating an encounter if actor quantity is numeric.

### DIFF
--- a/sheets/EncounterSheet.js
+++ b/sheets/EncounterSheet.js
@@ -327,7 +327,7 @@ export class EncounterSheet extends EnhancedJournalSheet {
                 //}
 
                 // Prepare the Token data
-                let quantity = (String(ea.quantity) || "1");
+                let quantity = String(ea.quantity || "1");
                 if (quantity.indexOf("d") != -1) {
                     let r = new Roll(quantity);
                     await r.evaluate({ async: true });

--- a/sheets/EncounterSheet.js
+++ b/sheets/EncounterSheet.js
@@ -327,7 +327,7 @@ export class EncounterSheet extends EnhancedJournalSheet {
                 //}
 
                 // Prepare the Token data
-                let quantity = (ea.quantity || "1");
+                let quantity = (String(ea.quantity) || "1");
                 if (quantity.indexOf("d") != -1) {
                     let r = new Roll(quantity);
                     await r.evaluate({ async: true });


### PR DESCRIPTION
There is a bug when dropping onto the canvas an encounter which includes actors whose quantity has not be edited.

Steps to reproduce:
- Create a new encounter.
- Add a new Actor to the encounter.
- DON'T touch the Actor quantity.
- Try to use the "drag to canvas" button.
- Notice how the Actor is not added to the canvas. 
- Notice how the console complains about "indexOf" being undefined at EncounterSheet.js line 331.

Reason:
When an actor is added to the encounter, its "quantity" field is initialized to `1` (numeric). However the encounter function tries to parse it as a string (expecting a roll expression).

Solution:
Convert the quantity field to string when processing the encounter.