### PR TITLE
Perception isn't listed when adding DC checks.

### DIFF
--- a/apps/dc-config.js
+++ b/apps/dc-config.js
@@ -24,7 +24,7 @@ export class DCConfig extends FormApplication {
         else if (game.system.id == "shadowrun5e")
             config = CONFIG.SR5;
         let attributeOptions = [
-            { id: "ability", text: "MonksEnhancedJournal.Ability", groups: config.abilities || config.scores || config.atributos },
+            { id: "ability", text: "MonksEnhancedJournal.Ability", groups: config.abilities || config.scores || config.attribute },
             { id: "skill", text: "MonksEnhancedJournal.Skill", groups: config.skills || config.pericias }
         ].filter(g => g.groups);
 


### PR DESCRIPTION
I noticed in the source what appeared to be a typo. Not sure if the previous spelling was for a particular system that had a typo, or if that is what was causing the error for Pathfinder 2e. Should it be intentional this spelling, could it be added that the attribute class be pulled in order to show perception DC checks.