### PR TITLE
Add config for default person fields

### DIFF
--- a/apps/editpersondefault.js
+++ b/apps/editpersondefault.js
@@ -1,0 +1,40 @@
+import { MonksEnhancedJournal, i18n } from "../monks-enhanced-journal.js";
+
+export class EditPersonDefault extends FormApplication {
+    constructor(object, options) {
+        super(object, options);
+
+        this.fields = game.settings.get('monks-enhanced-journal', 'person-default-fields');
+    }
+
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            id: "journal-editcurrency",
+            title: 'Edit Person Default Fields',
+            classes: ["edit-person-default-fields"],
+            template: "./modules/monks-enhanced-journal/templates/editdefaultfields.html",
+            width: 400,
+            height: "auto",
+            closeOnSubmit: true,
+            popOut: true,
+        });
+    }
+
+    getData(options) {
+        return {
+            fields: this.fields
+        };
+    }
+
+    _updateObject(event, formData) {
+        let fields = mergeObject(this.fields, formData);
+        game.settings.set('monks-enhanced-journal', 'person-default-fields', fields);
+        this.submitting = true;
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        $('button[name="submit"]', html).click(this._onSubmit.bind(this));
+    };
+}

--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -1978,6 +1978,32 @@ export class MonksEnhancedJournal {
     static isLootActor(lootsheet) {
         return ['lootsheetnpc5e', 'merchantsheetnpc', 'item-piles'].includes(lootsheet);
     }
+
+    static get defaultPersonFields(){
+        return {
+            'race': { name: "MonksEnhancedJournal.Race", value: true },
+            'gender': { name: "MonksEnhancedJournal.Gender", value: false },
+            'age': { name: "MonksEnhancedJournal.Age", value: true },
+            'eyes': { name: "MonksEnhancedJournal.Eyes", value: true },
+            'skin': { name: "MonksEnhancedJournal.Skin", value: false },
+            'hair': { name: "MonksEnhancedJournal.Hair", value: true },
+            'skin': { name: "MonksEnhancedJournal.Skin", value: false },
+            'life': { name: "MonksEnhancedJournal.LifeStatus", value: false },
+            'profession': { name: "MonksEnhancedJournal.Profession", value: false },
+            'voice': { name: "MonksEnhancedJournal.Voice", value: true },
+            'faction': { name: "MonksEnhancedJournal.Faction", value: false },
+            'height': { name: "MonksEnhancedJournal.Height", value: false },
+            'weight': { name: "MonksEnhancedJournal.Weight", value: false },
+            'traits': { name: "MonksEnhancedJournal.Traits", value: true },
+            'ideals': { name: "MonksEnhancedJournal.Ideals", value: true },
+            'bonds': { name: "MonksEnhancedJournal.Bonds", value: true },
+            'flaws': { name: "MonksEnhancedJournal.Flaws", value: true },
+            'longterm': { name: "MonksEnhancedJournal.LongTermGoal", value: false },
+            'shortterm': { name: "MonksEnhancedJournal.ShortTermGoal", value: false },
+            'beliefs': { name: "MonksEnhancedJournal.Beliefs", value: false },
+            'secret': { name: "MonksEnhancedJournal.Secret", value: false }
+        }
+    }
 }
 
 Hooks.on("renderJournalDirectory", async (app, html, options) => {

--- a/settings.js
+++ b/settings.js
@@ -1,5 +1,6 @@
 import { MonksEnhancedJournal, i18n } from "./monks-enhanced-journal.js"
 import { EditCurrency } from "./apps/editcurrency.js"
+import { EditPersonDefault } from "./apps/editpersondefault.js"
 
 export const registerSettings = function () {
 	// Register any custom module settings here
@@ -21,6 +22,17 @@ export const registerSettings = function () {
 		restricted: true,
 		type: EditCurrency
 	});
+
+	
+	game.settings.registerMenu(modulename, 'editPersonDefault', {
+		name: 'Edit Person Default Fields',
+		label: 'Edit Person Default Fields',
+		hint: 'Edit the default fields when creating a new Person Journal Entry',
+		icon: 'fas fa-user',
+		restricted: true,
+		type: EditPersonDefault
+	});
+	
 
 	game.settings.register(modulename, "allow-player", {
 		name: i18n("MonksEnhancedJournal.allow-player.name"),
@@ -250,5 +262,12 @@ export const registerSettings = function () {
 		default: true,
 		type: Boolean,
 		config: false
+	});
+
+	game.settings.register(modulename, "person-default-fields", {
+		scope: "world",
+		config: true,
+		default: MonksEnhancedJournal.defaultPersonFields,
+		type: Object,
 	});
 }

--- a/sheets/PersonSheet.js
+++ b/sheets/PersonSheet.js
@@ -65,29 +65,7 @@ export class PersonSheet extends EnhancedJournalSheet {
     }
 
     fieldlist() {
-        return {
-            'race': { name: "MonksEnhancedJournal.Race", value: true },
-            'gender': { name: "MonksEnhancedJournal.Gender", value: false },
-            'age': { name: "MonksEnhancedJournal.Age", value: true },
-            'eyes': { name: "MonksEnhancedJournal.Eyes", value: true },
-            'skin': { name: "MonksEnhancedJournal.Skin", value: false },
-            'hair': { name: "MonksEnhancedJournal.Hair", value: true },
-            'skin': { name: "MonksEnhancedJournal.Skin", value: false },
-            'life': { name: "MonksEnhancedJournal.LifeStatus", value: false },
-            'profession': { name: "MonksEnhancedJournal.Profession", value: false },
-            'voice': { name: "MonksEnhancedJournal.Voice", value: true },
-            'faction': { name: "MonksEnhancedJournal.Faction", value: false },
-            'height': { name: "MonksEnhancedJournal.Height", value: false },
-            'weight': { name: "MonksEnhancedJournal.Weight", value: false },
-            'traits': { name: "MonksEnhancedJournal.Traits", value: true },
-            'ideals': { name: "MonksEnhancedJournal.Ideals", value: true },
-            'bonds': { name: "MonksEnhancedJournal.Bonds", value: true },
-            'flaws': { name: "MonksEnhancedJournal.Flaws", value: true },
-            'longterm': { name: "MonksEnhancedJournal.LongTermGoal", value: false },
-            'shortterm': { name: "MonksEnhancedJournal.ShortTermGoal", value: false },
-            'beliefs': { name: "MonksEnhancedJournal.Beliefs", value: false },
-            'secret': { name: "MonksEnhancedJournal.Secret", value: false }
-        };
+        return game.settings.get('monks-enhanced-journal', 'person-default-fields');
     }
 
     _documentControls() {

--- a/templates/editdefaultfields.html
+++ b/templates/editdefaultfields.html
@@ -1,0 +1,15 @@
+<form class="edit-fields" autocomplete="off" onsubmit="event.preventDefault();">
+    {{#each fields}}
+    <div class="form-group">
+        <label for="content">{{localize this.name}}</label>
+        <div class="form-fields">
+            <input type="checkbox" name="{{@key}}.value" {{checked this.value}} />
+        </div>
+    </div>
+    {{/each}}
+    <footer class="sheet-footer flexrow">
+        <button type="button" name="submit">
+            <i class="far fa-save"></i> Save Changes
+        </button>
+    </footer>
+</form>


### PR DESCRIPTION
I was getting tired of manually changing every single Person journal entry to remove and add the same fields, so I added a config to have a global default that is used instead. The default field values are the same as before, I just moved them from the PersonSheet to the main file where the currency default is, so that all the defaults can stay in one place.