### PR TITLE
Allow for *reward-less* quests to be saved.

### DIFF
--- a/sheets/QuestSheet.js
+++ b/sheets/QuestSheet.js
@@ -291,9 +291,8 @@ export class QuestSheet extends EnhancedJournalSheet {
     _getSubmitData(updateData = {}) {
         let data = expandObject(super._getSubmitData(updateData));
 
-        let rewardid = Object.keys(data.reward)[0];
-
         if (data.reward) {
+            let rewardid = Object.keys(data.reward)[0];
             data.flags['monks-enhanced-journal'].rewards = duplicate(this.getRewardData() || []);
             for (let reward of data.flags['monks-enhanced-journal'].rewards) {
                 let dataReward = data.reward[reward.id];


### PR DESCRIPTION
Moved the declaration of `rewardid` into the `if(rewards exist)` statement so that if a quest is created without a reward an error doesn't occur as outlined in a recent comment on #136.  

Attempts to fix #136, and works on my local install.

This is my first Foundry related PR so please double check it...but it's a one line change so *fingers crossed*.