### PR TITLE
Update monks-enhanced-journal.css

### DIFF
--- a/css/monks-enhanced-journal.css
+++ b/css/monks-enhanced-journal.css
@@ -1681,6 +1681,7 @@ height: fit-content;*/
     font-size: 13px;
     text-align: left;
     align-items: center;
+    text-indent: 0;
 }
 
 .monks-journal-sheet.sheet .items-list .item-content{


### PR DESCRIPTION
Fix list item indention for the cyphersystem.

Before:
![monks-04](https://user-images.githubusercontent.com/251676/175327015-93a04250-5fe3-44cf-b4b0-7d723116cc53.png)

After:
![monks-03](https://user-images.githubusercontent.com/251676/175327104-7358ea53-3ae8-4896-989b-272360e186e7.png)

All entries are fixed and 5e system is still showing correctly.
