### PR TITLE
Prevent Shop crash when adding item with Decimal value and no alternate currencies

### DIFF
--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -547,7 +547,9 @@ export class EnhancedJournalSheet extends JournalSheet {
             currency = this.defaultCurrency();
 
         if (parseInt(price) != price) {
-            if (MonksEnhancedJournal.currencies.length) {
+            console.log(MonksEnhancedJournal.currencies);
+            if (MonksEnhancedJournal.currencies.length > 1) {
+                console.log(price.toString().split());
                 let numDecimal = price.toString().split(".")[1].length || 0;
                 let currs = MonksEnhancedJournal.currencies.filter(c => {
                     if (!c.convert)
@@ -570,10 +572,9 @@ export class EnhancedJournalSheet extends JournalSheet {
                 if (!curr) {
                     curr = MonksEnhancedJournal.currencies[MonksEnhancedJournal.currencies.length - 1];
                     currency = curr.id;
-                    price = Math.floor(price / curr.convert);
+                    price = Math.floor(price / (curr.convert || 1) );
                 }
-            } else
-                price = Math.floor(price);
+            } 
         }
 
         result.value = price;


### PR DESCRIPTION
This is an attempt to fix #287 which was raised for SWADE, but applies to DnD5e and likely other systems if there are no alternative currencies setup.

Two minor changes to the code:
```js
if (!curr) {
                    curr = MonksEnhancedJournal.currencies[MonksEnhancedJournal.currencies.length - 1];
                    currency = curr.id;
                    price = Math.floor(price / (curr.convert || 1) );
                }
```
Current code could set `price = some number / zero` and return "infinity" when the default currency was reached, since the `.convert` property would be `0`.  This was crashing the Shop screen.   Added the ` || 1` so that won't happen.


Second, I removed the `else` statement that rounded any remaining number down to the nearest integer.  In the above code, if running through alternate currencies, the numbers are already rounded off-- I don't think there should be any need to run them through Math.floor again in the else statement.

And by removing the final `else` statement systems without alternate currencies can still benefit from decimal values.   The downside is that some folks may prefer to play with only one currency (ex. Gold) but also do not want decimals.  This was me for my SWADE game, but I've only just become aware that SWADE core book has items worth less than 1 gold.

Perhaps a checkbox in the settings for "allow decimal values" is helpful.