### PR TITLE
Allow navigation directly to subpages of a journal entry

### DIFF
--- a/apps/enhanced-journal.js
+++ b/apps/enhanced-journal.js
@@ -122,6 +122,10 @@ export class EnhancedJournal extends Application {
             });
         }
 
+        if (options.pageId !== undefined) {
+            this.subsheet.goToPage(options.pageId, options?.anchor);
+        }
+
         return result;
     }
 
@@ -569,12 +573,18 @@ export class EnhancedJournal extends Application {
         if (entity?.currentTarget != undefined)
             entity = null;
 
+        if (entity.parent) {
+            var pageId = entity.id;
+            entity = entity.parent;
+        }
+
         let tab = {
             id: makeid(),
             text: entity?.name || i18n("MonksEnhancedJournal.NewTab"),
             active: false,
             entityId: entity?.uuid,
             entity: entity || { flags: { 'monks-enhanced-journal': { type: 'blank' }, content: i18n("MonksEnhancedJournal.NewTab") } },
+            pageId: pageId,
             history: []
         };
         if (tab.entityId != undefined)
@@ -652,6 +662,11 @@ export class EnhancedJournal extends Application {
     updateTab(tab, entity, options = {}) {
         if (!entity)
             return;
+
+        if (entity.parent) {
+            options.pageId = entity.id;
+            entity = entity.parent;
+        }
 
         if (tab != undefined) {
             if (tab.entityId != entity.uuid) {

--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -502,10 +502,19 @@ export class MonksEnhancedJournal {
 
             // Target 3 - World Document Link
             else {
-                const collection = game.collections.get(a.dataset.type);
-                if (!collection)
-                    return;
-                doc = collection.get(id);
+                var datatype = a.dataset.type;
+                if (datatype === 'JournalEntryPage') {
+                    const journal_collection = game.collections.get('JournalEntry');
+                    const journal_id = a.dataset.uuid.split('.')[1];
+                    const page_id = a.dataset.uuid.split('.')[3];
+                    const journal = journal_collection.get(journal_id);
+                    doc = journal.pages.get(page_id);
+                } else {
+                    const collection = game.collections.get(datatype);
+                    if (!collection)
+                        return;
+                    doc = collection.get(id);
+                }
                 if (!doc) return;
                 if ((doc.documentName === "Scene") && doc.journal) doc = doc.journal;
                 if (!doc.testUserPermission(game.user, "LIMITED")) {
@@ -831,7 +840,7 @@ export class MonksEnhancedJournal {
 
             let entity = this.page || this.entry;
             if (allowed && this.entry) {
-                if (!MonksEnhancedJournal.openJournalEntry(this.entry)) {
+                if (!MonksEnhancedJournal.openJournalEntry(this.entry, options)) {
                     let page = this.page;
                     if (this.entry.pages.size == 1) {
                         page = this.entry.pages.contents[0];
@@ -1438,14 +1447,15 @@ export class MonksEnhancedJournal {
 
         //if the enhanced journal is already open, then just pass it the new object, if not then let it render as normal
         if (MonksEnhancedJournal.journal) {
-            if (doc)
-                MonksEnhancedJournal.journal.open(doc, options.newtab, { anchor: options?.anchor, autoPage: true });
-            else
-                MonksEnhancedJournal.journal.render(true, { anchor: options?.anchor });
+            if (doc) {
+                options.autoPage = true;
+                MonksEnhancedJournal.journal.open(doc, options.newtab, options);
+            } else
+                MonksEnhancedJournal.journal.render(true, options);
+        } else {
+            options.autoPage = true;
+            MonksEnhancedJournal.journal = new EnhancedJournal(doc, options).render(true, options);
         }
-        else
-            MonksEnhancedJournal.journal = new EnhancedJournal(doc, { anchor: options?.anchor }).render(true, { autoPage: true });
-
         return true;
     }
 


### PR DESCRIPTION
Fixes issue https://github.com/ironmonk88/monks-enhanced-journal/issues/378 by including the pageId in the `options` passed to `_render` function and calling `this.subsheet.goToPage(pageId)` when a pageId is included.

I found that it was also not working for subpage document hotlinks within other journal entries because `game.collections` doesn't contain a datatype for 'JournalEntryPage' unfortunately. Each entry in the JournalEntry collection contains its own subpages so I had to drill into it in order to retrieve the correct JournalEntryPage.