### PR TITLE
Polyglot V2 support

### DIFF
--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -231,8 +231,6 @@ export class MonksEnhancedJournal {
         if (!(CONFIG.TinyMCE.content_css instanceof Array))
             CONFIG.TinyMCE.content_css = [CONFIG.TinyMCE.content_css];
         CONFIG.TinyMCE.content_css.push('modules/monks-enhanced-journal/css/editor.css');
-        if (game.modules.get("polyglot")?.active)
-            CONFIG.TinyMCE.content_css.push('modules/polyglot/css/polyglot.css');
 
         CONFIG.TinyMCE.style_formats.push({
             title: "Enhanced Journal",
@@ -2400,14 +2398,6 @@ export class MonksEnhancedJournal {
         if (setting("add-create-link"))
             tinyMCE.PluginManager.add('createlink', createlinkinit);
 
-        // Preload fonts for polyglot so there isn't a delay in showing them, and possibly revealing something
-        if (game.modules.get("polyglot")?.active && !isNewerVersion(game.modules.get("polyglot")?.version, "1.7.30")) {
-            let root = $('<div>').attr('id', 'enhanced-journal-fonts').appendTo('body');
-            for (let [k, v] of Object.entries(polyglot.polyglot.LanguageProvider.alphabets)) {
-                $('<span>').attr('lang', k).css({ font: v }).appendTo(root);
-            }
-        }
-
         let oldDragMouseUp = Draggable.prototype._onDragMouseUp;
         Draggable.prototype._onDragMouseUp = function (event) {
             Hooks.call(`dragEnd${this.app.constructor.name}`, this.app);
@@ -4328,7 +4318,7 @@ Hooks.on("updateSetting", (setting, data, options, userid) => {
 Hooks.on("polyglot.ready", () => {
     try {
         let root = $('<div>').attr('id', 'enhanced-journal-fonts').appendTo('body');
-        let alphabets = game.polyglot.LanguageProvider?.alphabets || game.polyglot.languageProvider?.alphabets;
+        let alphabets = game.polyglot.languageProvider?.alphabets;
         if (alphabets) {
             for (let [k, v] of Object.entries(alphabets)) {
                 $('<span>').attr('lang', k).css({ font: v }).appendTo(root);

--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -395,86 +395,9 @@ export class EnhancedJournalSheet extends JournalPageSheet {
     activateEditor(name, options = {}, initialContent = "") {
         $('.editor .editor-content', this.element).unmark();
 
-        let polyglot = (isNewerVersion(game.modules.get("polyglot")?.version, "1.7.30") ? game.polyglot : polyglot?.polyglot);
-
         if (this.editors[name] != undefined) {
-            if (game.modules.get("polyglot")?.active && polyglot) {
-                let polyLangs = polyglot.LanguageProvider?.languages || game.polyglot.languageProvider?.languages;
-                if (!game.user.isGM) {
-                    var langs = {};
-                    
-                    for (let lang of polyglot.known_languages) {
-                        langs[lang] = polyLangs[lang];
-                    }
-                    for (let lang of polyglot.literate_languages) {
-                        langs[lang] = polyLangs[lang];
-                    }
-                } else langs = polyLangs;
-
-                const languages = Object.entries(langs).map(([lang, name]) => {
-                    return {
-                        title: name || "",
-                        inline: "span",
-                        classes: "polyglot-journal",
-                        attributes: {
-                            title: name || "",
-                            "data-language": lang || "",
-                        },
-                    };
-                });
-                if (this.truespeech) {
-                    const truespeechIndex = languages.findIndex((element) => element.attributes["data-language"] == this.truespeech);
-                    if (truespeechIndex !== -1) languages.splice(truespeechIndex, 1);
-                }
-                if (this.comprehendLanguages && !this._isTruespeech(this.comprehendLanguages)) {
-                    const comprehendLanguagesIndex = languages.findIndex((element) => element.attributes["data-language"] == this.comprehendLanguages);
-                    if (comprehendLanguagesIndex !== -1) languages.splice(comprehendLanguagesIndex, 1);
-                }
-                options.style_formats = [
-                    ...CONFIG.TinyMCE.style_formats,
-                    {
-                        title: "Polyglot",
-                        items: languages,
-                    },
-                ];
-                options.formats = {
-                    removeformat: [
-                        // Default remove format configuration from tinyMCE
-                        {
-                            selector: "b,strong,em,i,font,u,strike,sub,sup,dfn,code,samp,kbd,var,cite,mark,q,del,ins",
-                            remove: "all",
-                            split: true,
-                            expand: false,
-                            block_expand: true,
-                            deep: true,
-                        },
-                        {
-                            selector: "span",
-                            attributes: ["style", "class"],
-                            remove: "empty",
-                            split: true,
-                            expand: false,
-                            deep: true,
-                        },
-                        {
-                            selector: "*",
-                            attributes: ["style", "class"],
-                            split: false,
-                            expand: false,
-                            deep: true,
-                        },
-                        // Add custom config to remove spans from polyglot when needed
-                        {
-                            selector: "span",
-                            classes: "polyglot-journal",
-                            attributes: ["title", "class", "data-language"],
-                            remove: "all",
-                            split: true,
-                            expand: false,
-                            deep: true,
-                        },
-                    ],
-                };
+            if (game.modules.get("polyglot")?.active && game.polyglot) {
+                game.polyglot.activeEditorLogic(options);
             }
 
             options = foundry.utils.mergeObject(options, {


### PR DESCRIPTION
Fixes #600 (https://github.com/ironmonk88/monks-enhanced-journal/issues/600#issuecomment-1657283665)

I'll release an update for Polyglot that will refactor some code, and it will break this implementation:
https://github.com/ironmonk88/monks-enhanced-journal/blob/a347e5737accd3f2f65d488cc49e11d44d3ca6f6/sheets/EnhancedJournalSheet.js#L414-L424C20

On Polyglot's side, I've added a method to make it so there is no need for copy-pasting Polyglot's code, so any future changes on Polyglot should not require an update here.

I've also cleaned up some Polyglot support features that became unnecessary (support for V9 Polyglot, the push to TinyMCE, etc).

---

I want to thank you for your support for Polyglot, your code gave me some insight on breaking changes that I didn't thought of during the refactoring that would impact other devs.