### PR TITLE
Show GM defunct relationships

### DIFF
--- a/css/monks-enhanced-journal.css
+++ b/css/monks-enhanced-journal.css
@@ -1350,3 +1350,8 @@ body[inline-roll-styling="true"] a.tile-trigger-link i {
 #customise-page .shop-config-type-label:last-child {
     display: none;
 }
+
+.relationship-defunct {
+    text-decoration: line-through;
+    color: red;
+}

--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -495,6 +495,7 @@ export class EnhancedJournalSheet extends JournalPageSheet {
                     item.shoptype = "";
                     item.role = "";
                     item.defunct = true;
+                    item.name = item.name || i18n("MonksEnhancedJournal.Unknown");
                     
                     if (!relationships[type])
                         relationships[type] = {

--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -487,9 +487,25 @@ export class EnhancedJournalSheet extends JournalPageSheet {
         let relationships = {};
         for (let item of (this.object.flags['monks-enhanced-journal']?.relationships || [])) {
             let entity = item.uuid ? await fromUuid(item.uuid) : game.journal.get(item.id);
-            if (!(entity instanceof JournalEntry || entity instanceof JournalEntryPage))
-                continue;
-            if (entity && entity.testUserPermission(game.user, "LIMITED") && (game.user.isGM || !item.hidden)) {
+            if (!(entity instanceof JournalEntry || entity instanceof JournalEntryPage)) {
+                if (game.user.isGM) {
+                    let type = "defunct";
+
+                    item.img = `modules/monks-enhanced-journal/assets/loading.gif`;
+                    item.shoptype = "";
+                    item.role = "";
+                    item.defunct = true;
+                    
+                    if (!relationships[type])
+                        relationships[type] = {
+                            type: type,
+                            name: i18n("MonksEnhancedJournal.Unknown"),
+                            documents: []
+                        };
+
+                    relationships[type].documents.push(item);
+                }
+            } else if (entity && entity.testUserPermission(game.user, "LIMITED") && (game.user.isGM || !item.hidden)) {
                 let page = (entity instanceof JournalEntryPage ? entity : entity.pages.contents[0]);
                 MonksEnhancedJournal.fixType(page);
                 let type = getProperty(page, "flags.monks-enhanced-journal.type");
@@ -508,6 +524,7 @@ export class EnhancedJournalSheet extends JournalPageSheet {
                 item.type = type;
                 item.shoptype = page.getFlag("monks-enhanced-journal", "shoptype");
                 item.role = page.getFlag("monks-enhanced-journal", "role");
+                delete item.defunct;
 
                 relationships[type].documents.push(item);
             }

--- a/templates/sheets/organization.html
+++ b/templates/sheets/organization.html
@@ -59,7 +59,7 @@
                                 <li class="item flexrow" data-id="{{this.id}}" data-uuid="{{this.uuid}}" data-container="relationships" data-document="JournalEntry" draggable="false">
                                     <div class="item-name clickable flexrow">
                                         <img class="item-image large actor-icon" src="{{this.img}}" onerror="if (!this.imgerr) { this.imgerr = true; this.src = 'modules/monks-enhanced-journal/assets/{{this.type}}.png' }" />
-                                        <h4><a>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
+                                        <h4><a{{#if this.defunct}} class="relationship-defunct"{{/if}}>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
                                     </div>
 
                                     <div class="item-name item-relationship flexrow">

--- a/templates/sheets/person.html
+++ b/templates/sheets/person.html
@@ -93,7 +93,7 @@
                                 <li class="item flexrow" data-id="{{this.id}}" data-uuid="{{this.uuid}}" data-container="relationships" data-document="JournalEntry" draggable="false">
                                     <div class="item-name clickable flexrow">
                                         <img class="item-image large actor-icon" src="{{this.img}}" onerror="if (!this.imgerr) { this.imgerr = true; this.src = 'modules/monks-enhanced-journal/assets/{{this.type}}.png' }" />
-                                        <h4><a>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
+                                        <h4><a{{#if this.defunct}} class="relationship-defunct"{{/if}}>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
                                     </div>
 
                                     <div class="item-name item-relationship flexrow">

--- a/templates/sheets/place.html
+++ b/templates/sheets/place.html
@@ -168,7 +168,7 @@
                                 <li class="item flexrow" data-id="{{this.id}}" data-uuid="{{this.uuid}}" data-container="relationships" data-document="JournalEntry" draggable="false">
                                     <div class="item-name clickable flexrow">
                                         <img class="item-image large actor-icon" src="{{this.img}}" onerror="if (!this.imgerr) { this.imgerr = true; this.src = 'modules/monks-enhanced-journal/assets/{{this.type}}.png' }" />
-                                        <h4><a>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
+                                        <h4><a{{#if this.defunct}} class="relationship-defunct"{{/if}}>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
                                     </div>
 
                                     <div class="item-name item-relationship flexrow">

--- a/templates/sheets/poi.html
+++ b/templates/sheets/poi.html
@@ -46,7 +46,7 @@
                                 <li class="item flexrow" data-id="{{this.id}}" data-uuid="{{this.uuid}}" data-container="relationships" data-document="JournalEntry" draggable="false">
                                     <div class="item-name clickable flexrow">
                                         <img class="item-image large actor-icon" src="{{this.img}}" onerror="if (!this.imgerr) { this.imgerr = true; this.src = 'modules/monks-enhanced-journal/assets/{{this.type}}.png' }" />
-                                        <h4><a>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
+                                        <h4><a{{#if this.defunct}} class="relationship-defunct"{{/if}}>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
                                     </div>
 
                                     <div class="item-name item-relationship flexrow">

--- a/templates/sheets/quest.html
+++ b/templates/sheets/quest.html
@@ -304,7 +304,7 @@
                                 <li class="item flexrow" data-id="{{this.id}}" data-uuid="{{this.uuid}}" data-container="relationships" data-document="JournalEntry" draggable="false">
                                     <div class="item-name clickable flexrow">
                                         <img class="item-image large actor-icon" src="{{this.img}}" onerror="if (!this.imgerr) { this.imgerr = true; this.src = 'modules/monks-enhanced-journal/assets/{{this.type}}.png' }" />
-                                        <h4><a>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
+                                        <h4><a{{#if this.defunct}} class="relationship-defunct"{{/if}}>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
                                     </div>
 
                                     <div class="item-name item-relationship flexrow">

--- a/templates/sheets/shop.html
+++ b/templates/sheets/shop.html
@@ -239,7 +239,7 @@
                                 <li class="item flexrow" data-id="{{this.id}}" data-uuid="{{this.uuid}}" data-container="relationships" data-document="JournalEntry" draggable="false">
                                     <div class="item-name clickable flexrow">
                                         <img class="item-image large actor-icon" src="{{this.img}}" onerror="if (!this.imgerr) { this.imgerr = true; this.src = 'modules/monks-enhanced-journal/assets/{{this.type}}.png' }" />
-                                        <h4><a>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
+                                        <h4><a{{#if this.defunct}} class="relationship-defunct"{{/if}}>{{#if this.pack}}<i class="fas fa-atlas" title="{{localize 'MonksEnhancedJournal.FromCompendium'}}"></i> {{/if}}{{this.name}}</a></h4>
                                     </div>
 
                                     <div class="item-name item-relationship flexrow">


### PR DESCRIPTION
Defunct relationships (item deleted) are hidden from everyone but still stored in the flags.
This can lead to increased collisions in ID matching.
This allows the GM to see defunct relationships and remove them if needed through the UI.