### PR TITLE
fix: add additional selector for hyperlink css specificity

### DIFF
--- a/css/monks-enhanced-journal.css
+++ b/css/monks-enhanced-journal.css
@@ -934,6 +934,7 @@ span.unknown-link {
 
 body[inline-roll-styling="true"] a.entity-link,
 body[inline-roll-styling="true"] a.content-link,
+body[inline-roll-styling="true"] .locked-tooltip.link-matches a.content-link
 body[inline-roll-styling="true"] a.inline-roll,
 body[inline-roll-styling="true"] a.picture-link,
 body[inline-roll-styling="true"] a.sound-link,


### PR DESCRIPTION
fixes #662 and fixes #691

CSS Specificity issue. Not 100% sure if the selector is *too* specific but it's require unless you want to resort to `!important`