### PR TITLE
#693 Add [[/award ...]] currency parsing to roll table handling

### DIFF
--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -1920,6 +1920,25 @@ export class EnhancedJournalSheet extends JournalPageSheet {
                                                 currChanged = true;
                                             }
                                         }
+                                        
+                                        // DND5E Award Enricher Parsing
+                                        if (text.startsWith("[[/award") && text.endsWith("]]")) {
+                                            const award = text.substring(2, text.length - 2);
+                                            for (const part of award.replace(/^\/award(?:\s|$)/i, "").split(" ")) {
+                                                if (!part) continue;
+                                                let [,formula, coin] = part.match(/^(.+?)(\D+)$/) ?? [];
+                                                coin = coin?.toLowerCase();
+                                                if (coin === "xp") continue;
+                                                
+                                                if (coin == undefined || coin.length == 0 || MonksEnhancedJournal.currencies.find(c => c.id == coin) == undefined) {
+                                                    coin = MEJHelpers.defaultCurrency();
+                                                }
+
+                                                let value = await tryRoll(formula);
+                                                currency[coin] = (currency[coin] || 0) + value;
+                                                currChanged = true;
+                                            }
+                                        }
                                     }
                             }
                             /*

--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -1923,8 +1923,8 @@ export class EnhancedJournalSheet extends JournalPageSheet {
                                         
                                         // DND5E Award Enricher Parsing
                                         if (text.startsWith("[[/award") && text.endsWith("]]")) {
-                                            const award = text.substring(2, text.length - 2);
-                                            for (const part of award.replace(/^\/award(?:\s|$)/i, "").split(" ")) {
+                                            const award = text.substring(8, text.length - 2);
+                                            for (const part of award.split(" ")) {
                                                 if (!part) continue;
                                                 let [,formula, coin] = part.match(/^(.+?)(\D+)$/) ?? [];
                                                 coin = coin?.toLowerCase();


### PR DESCRIPTION
# Feature #693

Update populating Loot journal entries from RollTable's to support the [dnd5e award enricher syntax](https://github.com/foundryvtt/dnd5e/wiki/Awards).  Continue to support old syntax, add "overload" to handle [[/award ... ]] type currency definitions.