### PR TITLE
Separate setting to open actors outside

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -20,6 +20,8 @@
   "MonksEnhancedJournal.use-objectives.hint": "Füge Ziele zu Questeinträgen hinzu",
   "MonksEnhancedJournal.open-outside.name": "Öffne Chat-Links",
   "MonksEnhancedJournal.open-outside.hint": "Öffne Chat-Links außerhalb von Enhanced Journal, anstatt einem neuem Tab",
+  "MonksEnhancedJournal.open-actors-outside.name": "Öffne Akteur-Links",
+  "MonksEnhancedJournal.open-actors-outside.hint": "Öffne Akteur-Links außerhalb von Enhanced Journal, anstatt einem neuem Tab",
   "MonksEnhancedJournal.show-folder-sort.name": "Zeige Ordnersortierung an",
   "MonksEnhancedJournal.show-folder-sort.hint": "Zeige ein umrissenes Bild, wenn Dein Ordner manuell sortiert ist",
   "MonksEnhancedJournal.show-zero-quantity.name": "Zeige 0 Anzahl an.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,6 +20,8 @@
   "MonksEnhancedJournal.use-objectives.hint": "Add Objectives to Quests entries",
   "MonksEnhancedJournal.open-outside.name": "Open Links",
   "MonksEnhancedJournal.open-outside.hint": "Open Links outside of Enhanced Journal instead of a new tab",
+  "MonksEnhancedJournal.open-actors-outside.name": "Open Actors",
+  "MonksEnhancedJournal.open-actors-outside.hint": "Open Actors outside of Enhanced Journal instead of a new tab",
   "MonksEnhancedJournal.show-folder-sort.name": "Show Folder Sorting",
   "MonksEnhancedJournal.show-folder-sort.hint": "Show an outlined image if your folder is sorted manually",
   "MonksEnhancedJournal.show-zero-quantity.name": "Show Zero Quantity",

--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -739,7 +739,7 @@ export class MonksEnhancedJournal {
         }
         */
         Actor.prototype._onClickDocumentLink = function (event) {
-            if (event.altKey || setting('open-outside') || !MonksEnhancedJournal.openJournalEntry(this, { newtab: event.ctrlKey && !setting("open-new-tab") })) {
+            if (event.altKey || setting('open-outside') || setting('open-actors-outside') || !MonksEnhancedJournal.openJournalEntry(this, { newtab: event.ctrlKey && !setting("open-new-tab") })) {
                 return this.sheet.render(true);
             }
         }

--- a/settings.js
+++ b/settings.js
@@ -290,6 +290,15 @@ export const registerSettings = function () {
 		type: Boolean,
 	});
 
+	game.settings.register(modulename, "open-actors-outside", {
+		name: i18n("MonksEnhancedJournal.open-actors-outside.name"),
+		hint: i18n("MonksEnhancedJournal.open-actors-outside.hint"),
+		scope: "world",
+		config: true,
+		default: true,
+		type: Boolean,
+	});
+
 	game.settings.register(modulename, "show-folder-sort", {
 		name: i18n("MonksEnhancedJournal.show-folder-sort.name"),
 		hint: i18n("MonksEnhancedJournal.show-folder-sort.hint"),


### PR DESCRIPTION
Hey there,

I added a new setting so that it is possible to open links inside enhanced journal but actors pop open outside of it. 

Some systems (I had the issue with Level Up: Advanced 5th Edition) do not render the actor sheet inside Enhanced Journal at all and furthermore, after trying to open an actor link inside of Enhanced Journal, the actor sheet can not be opened by any means anymore. It needs a complete browser refresh to be able to open an actor sheet again.

Best Regards,
Syrious