### PR TITLE
Prevent journal title input field from submitting on "Enter"

### DIFF
--- a/templates/sheets/partials/journal_pages.hbs
+++ b/templates/sheets/partials/journal_pages.hbs
@@ -2,7 +2,8 @@
     {{!-- Journal Entry Name --}}
     <header class="journal-header">
         <input class="title" name="name" type="text" value="{{ document.name }}"
-               placeholder="{{ localize "JOURNAL.EntryTitle" }}" aria-label="{{ localize "JOURNAL.EntryTitle" }}">
+               placeholder="{{ localize "JOURNAL.EntryTitle" }}" aria-label="{{ localize "JOURNAL.EntryTitle" }}"
+               onkeydown="if (event.key === 'Enter') { event.preventDefault(); event.stopPropagation(); }">
     </header>
 
     <div class="journal-entry-pages scrollable {{ ifThen editable "editable" "locked" }}"></div>


### PR DESCRIPTION
Prevent default behavior on Enter key in journal title input.

Currently if you press Enter in the title input field, it causes Foundry/Browser to submit and reload, this reload also breaks some CSS and layout of the entire Foundry UI. Not sure if this is the correct way of fixing this issue, but I made this change on my and to just quickly solve whatever is happening, everything else seem to function as intended after this change as far as I can tell.

To clarify, this is for the Native Journal Entries and not for the Enhanced Journal entries, the issue also only shows up with this module enabled so traced issue to this.
Enhanced Journal entries do not seem to have this same problem with the journal title field.