### PR TITLE
Add support for the Dungeon Crawl Classics (dcc) system

### DIFF
--- a/monks-enhanced-journal.js
+++ b/monks-enhanced-journal.js
@@ -3671,7 +3671,7 @@ export class MonksEnhancedJournal {
 					delete itemData._id;
 					if (!data.consumable) {
 						let sheet = actor.sheet;
-						if (sheet._onDropItem)
+						if (sheet._onDropItem && game.system.id != "dcc")
 							sheet._onDropItem({ preventDefault: () => { }, target: { closest: () => { } } }, itemData);
 						else
 							actor.createEmbeddedDocuments("Item", [itemData]);
@@ -4269,6 +4269,14 @@ export class MonksEnhancedJournal {
 					{ id: "cp", name: "cp", convert: 0.1 },
 					{ id: "bits", name: "bits", convert: 0.01 }
 				];
+			case "dcc":
+				return [
+					{ id: "pp", name: i18n("MonksEnhancedJournal.currency.platinum"), convert: 100 },
+					{ id: "ep", name: i18n("MonksEnhancedJournal.currency.electrum"), convert: 10 },
+					{ id: "gp", name: i18n("MonksEnhancedJournal.currency.gold"), convert: 0 },
+					{ id: "sp", name: i18n("MonksEnhancedJournal.currency.silver"), convert: 0.1 },
+					{ id: "cp", name: i18n("MonksEnhancedJournal.currency.copper"), convert: 0.01 }
+				];
 			default:
 				return [];
 		}
@@ -4516,7 +4524,7 @@ Hooks.on('dropActorSheetData', (actor, sheet, data) => {
 						if (!setting("use-generic-price"))
 							setPrice(data.data, pricename(), result.price);
 						data.uuid = `${data.uuid}${data.rewardId ? `.Rewards.${data.rewardId}` : ""}.Items.${data.itemId}`;
-						if (sheet._onDropItem && game.system.id != "cyphersystem")
+						if (sheet._onDropItem && game.system.id != "cyphersystem" && game.system.id != "dcc")
 							sheet._onDropItem({ preventDefault: () => { }, target: { closest: () => { } } }, data.data);
 						else
 							actor.createEmbeddedDocuments("Item", [data.data]);

--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -3555,7 +3555,7 @@ export class EnhancedJournalSheet extends HandlebarsApplicationMixin(foundry.app
                 let itemQty = getValue(itemData, quantityname(), 1);
                 setValue(itemData, quantityname(), item.qty * itemQty);
                 let sheet = destActor.sheet;
-                if (sheet._onDropItem)
+                if (sheet._onDropItem && game.system.id != "dcc")
                     sheet._onDropItem({ preventDefault: () => { }, target: { closest: () => { } } }, itemData);
                 else
                     destActor.createEmbeddedDocuments("Item", [itemData]);

--- a/sheets/ShopSheet.js
+++ b/sheets/ShopSheet.js
@@ -593,7 +593,7 @@ export class ShopSheet extends EnhancedJournalSheet {
                         setPrice(itemData, pricename(), result.price);
                     if (!data.consumable) {
                         let sheet = actor.sheet;
-                        if (sheet._onDropItem)
+                        if (sheet._onDropItem && game.system.id != "dcc")
                             sheet._onDropItem({ preventDefault: () => { }, target: { closest: () => { } } }, itemData );
                         else
                             actor.createEmbeddedDocuments("Item", [itemData]);


### PR DESCRIPTION
DCC stores currency at `actor.system.currency.{pp,ep,gp,sp,cp}` as plain integer fields, which the default code path already targets correctly, but `MonksEnhancedJournal.defaultCurrencies` returns an empty array for unrecognized systems. 
* Add a `dcc` case to seed the five standard denominations.

DCC's V14 actor sheet (DCCActorSheet extends ActorSheetV2) inherits the core `_onDropItem(event, item)` which expects a Document instance and calls `item.toObject()` on it. The shop's purchase paths pass raw item data, which errors inside ActorSheetV2 and silently aborts. 

* Skip `_onDropItem` for `dcc` so it falls through to `actor.createEmbeddedDocuments`, matching the existing handling for `cyphersystem`.
* Apply the exclusion to the three other call sites that were missing it as well.

Reported by users on the foundryvtt-dcc Discord.