### PR TITLE
Relationships Hide Status is now equal in each entry.

### DIFF
--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -2688,7 +2688,7 @@ export class EnhancedJournalSheet extends HandlebarsApplicationMixin(foundry.app
                     let otherRelationships = foundry.utils.duplicate(foundry.utils.getProperty(page, "flags.monks-enhanced-journal.relationships") || {});
                     let otherRelationship = Object.values(otherRelationships).find(value => value.uuid == this.document.uuid || value.uuid == this.document.parent.uuid);
                     if (otherRelationship) {
-                        otherRelationship.hidden = !otherRelationship.hidden;
+                        otherRelationship.hidden = items[id].hidden;
                         page.setFlag('monks-enhanced-journal', "relationships", otherRelationships);
                     }
                 }

--- a/sheets/EnhancedJournalSheet.js
+++ b/sheets/EnhancedJournalSheet.js
@@ -3135,7 +3135,7 @@ export class EnhancedJournalSheet extends HandlebarsApplicationMixin(foundry.app
                 if (original.isOwner && orgPage.isOwner) {
                     MonksEnhancedJournal.fixType(orgPage);
                     let sheet = orgPage.sheet;
-                    sheet.addRelationship({ id: this.document.parent.id, uuid: this.document.parent.uuid, hidden: true }, false);
+                    sheet.addRelationship({ id: this.document.parent.id, uuid: this.document.parent.uuid, hidden: this.document.parent.hidden }, false);
                 } else {
                     MonksEnhancedJournal.emit("addRelationship", { uuid: relationship.uuid, relationship: { id: this.document.parent.id, uuid: this.document.parent.uuid }, page: this.document.id, hidden: true });
                 }


### PR DESCRIPTION
Now it uses the value of the original relationship being changed instead of just `!` itself.

Perhaps there is a problem in how relationship-hide-status is originally created and there must be no instances where the values differ?

fixes https://github.com/ironmonk108/monks-enhanced-journal/issues/808 (probably? Not sure what is the intended use)